### PR TITLE
Fix footer expanding past parent container

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -59,7 +59,7 @@ HHHHHH       →→HHHH
     <div id="fb-root"></div>
     <div id="twitter-wjs"></div>
     <footer>
-      <div class="container">
+      <div class="container-fluid">
         <div class="row">
           <div class="col-md-4">
             <span class="copyright">&copy; <%= site_name %> <%= Time.now.year %></span>


### PR DESCRIPTION
Should be `container-fluid` instead of `container` since it is a fluid layout.
