### PR TITLE
Fix info button background color

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -66,7 +66,7 @@ small, .help-block {
 .btn-info.active:focus,
 .btn-info:active.focus,
 .btn-info.active.focus {
-  background-color: $light-gray;
+  background-color: $lighter-gray;
   color: $darker-gray;
   border: none;
 }


### PR DESCRIPTION
Accidentally made it darker when replacing with variables.
## Before

![screen shot 2016-07-03 at 4 08 13 pm](https://cloud.githubusercontent.com/assets/71852/16548099/6846df74-4138-11e6-9ffb-824f1ec9a225.png)
## After

![screen shot 2016-07-03 at 4 08 00 pm](https://cloud.githubusercontent.com/assets/71852/16548101/6d2dd948-4138-11e6-90c4-ef22a5e956d2.png)
