### PR TITLE
Don't let user change their email address once their email is verified

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,6 @@
 class User < ActiveRecord::Base
   include ActionView::Helpers::NumberHelper
+  include ActiveModel::Dirty
 
   MAX_DOMESTIC_PHONE_NUMBER = 12
   MAX_INTERNATIONAL_PHONE_NUMBER = 14
@@ -11,6 +12,7 @@ class User < ActiveRecord::Base
   validates_format_of :email,
     :with => /\A[^@\s]+@([^@\s]+\.)+[^@\s]+\z/,
     allow_nil: true
+  validate :no_changes_to_email_after_confirmed
 
   before_create :create_confirmation_token
 
@@ -65,6 +67,12 @@ class User < ActiveRecord::Base
       end
     elsif phone.size < MAX_DOMESTIC_PHONE_NUMBER
       self.errors.add(:phone, "number is too short: #{phone}")
+    end
+  end
+
+  def no_changes_to_email_after_confirmed
+    if email_changed? && email_confirmed && !email_confirmed_changed?
+      self.errors.add(:email, "cannot be changed after being confirmed")
     end
   end
 

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -10,7 +10,7 @@
     .form-fields
       .form-group
         = f.label :email, 'Your email address:'
-        = f.email_field :email, placeholder: 'Email', class: 'form-control'
+        = f.email_field :email, placeholder: 'Email', readonly: @user.email_confirmed, class: 'form-control'
         %span We'll send you email notifications.
 
       .form-group

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -131,4 +131,10 @@ RSpec.describe User, type: :model do
       .to raise_error(/is too long: \+45440-455-5121/)
   end
 
+  it "is not possible to change the email after being confirmed" do 
+    user = FactoryGirl.create(:user, email_confirmed: true)
+    expect { user.update_attributes!(email: "test@example.com") }
+      .to raise_error ActiveRecord::RecordInvalid
+  end
+
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -131,7 +131,7 @@ RSpec.describe User, type: :model do
       .to raise_error(/is too long: \+45440-455-5121/)
   end
 
-  it "is not possible to change the email after being confirmed" do 
+  it "is not valid to change the email after being confirmed" do 
     user = FactoryGirl.create(:user, email_confirmed: true)
     expect { user.update_attributes!(email: "test@example.com") }
       .to raise_error ActiveRecord::RecordInvalid


### PR DESCRIPTION
Addresses this issue: https://github.com/DevProgress/HillaryBNB/issues/64

Blocked on the back end using a dirty record validation.

Blocked on the front end by using a read-field on email once the user is confirmed. Debated adding some sort of messaging when it's read only. Something like "Your email cannot be updated once confirmed" Easy enough to add in if you think it would help.
<img width="722" alt="screen shot 2016-10-13 at 12 26 03 am" src="https://cloud.githubusercontent.com/assets/1066625/19340105/04ff543e-90dc-11e6-8562-679ea47c2552.png">
