### PR TITLE
add accomodation type to email digest and visit#show page

### DIFF
--- a/app/decorators/hosting_decorator.rb
+++ b/app/decorators/hosting_decorator.rb
@@ -10,7 +10,11 @@ class HostingDecorator < Draper::Decorator
   end
 
   def guest_details
-    (accomodation_type == 'home' ? 'private home' : 'hotel share') + ", " + num_guest_details
+    pretty_accomodation_type + ", " + num_guest_details
+  end
+
+  def pretty_accomodation_type
+    accomodation_type == 'home' ? 'private home' : 'hotel share'
   end
 
   def short_details

--- a/app/views/user_mailer/new_hosts_digest.html.erb
+++ b/app/views/user_mailer/new_hosts_digest.html.erb
@@ -5,7 +5,7 @@ Here's a list of all the new hosts available for your visit to <%= @visit.city %
 <hr>
 
 <% @host_data.each do |listing| %>
-  <%= listing[:host].first_name %> signed up as a host <%= listing[:hosting].distance_from(@visit).round(1) %> mi. from <%= @visit.city || @visit.zipcode %> with availability from <%= listing[:hosting].start_date %> through <%= listing[:hosting].end_date %>.
+  <%= listing[:host].first_name %> signed up as a host of a <%= listing[:hosting].decorate.pretty_accomodation_type %> <%= listing[:hosting].distance_from(@visit).round(1) %> mi. from <%= @visit.city || @visit.zipcode %> with availability from <%= listing[:hosting].start_date %> through <%= listing[:hosting].end_date %>.
   <br><br>
 
   <% unless listing[:hosting].comment.empty? %>

--- a/app/views/visits/_hosts.html.haml
+++ b/app/views/visits/_hosts.html.haml
@@ -21,7 +21,7 @@
           %li
             %span #{ hosting.city || hosting.zipcode } - #{ hosting.distance.round(1) } miles
           %li
-            %small Space for #{ hosting.max_guests }
+            %small Space for #{ hosting.max_guests } in a #{ hosting.decorate.pretty_accomodation_type }
           %li
             %small Available #{ hosting.start_and_end_dates }
       %a{ href: "##{ tab_id }",


### PR DESCRIPTION
Addresses https://github.com/DevProgress/HillaryBNB/issues/81.

On the visits/show page:
<img width="744" alt="screen shot 2016-10-15 at 4 50 00 pm" src="https://cloud.githubusercontent.com/assets/1066625/19414127/320833a6-92f8-11e6-97e6-96da54ae73ec.png">

In the nightly digest email: 
<img width="753" alt="screen shot 2016-10-15 at 4 56 34 pm" src="https://cloud.githubusercontent.com/assets/1066625/19414134/68266a70-92f8-11e6-9a7a-8d375eb5ac0c.png">
