### PR TITLE
Back end to allow visits and hostings to start yesterday

### DIFF
--- a/app/models/hosting.rb
+++ b/app/models/hosting.rb
@@ -37,7 +37,9 @@ class Hosting < ActiveRecord::Base
   end
 
   def validate_start_date_is_not_in_the_past
-    errors.add(:start_date, :in_past) unless start_date >= Time.zone.now.beginning_of_day
+    # We compare to yesterday because user's "today" may be yesterday in UTC.  But
+    # we're OK since datepicker in javascript enforces using the user's time zone.
+    errors.add(:start_date, :in_past) unless start_date >= Date.current - 1.day
   end
 
   def start_and_end_dates

--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -24,7 +24,9 @@ class Visit < ActiveRecord::Base
   acts_as_paranoid
 
   def validate_start_date_is_not_in_the_past
-    errors.add(:start_date, :in_past) unless start_date >= Time.zone.now.beginning_of_day
+    # We compare to yesterday because user's "today" may be yesterday in UTC.  But
+    # we're OK since datepicker in javascript enforces using the user's time zone.
+    errors.add(:start_date, :in_past) unless start_date >= Date.current - 1.day
   end
 
   def available_hostings(current_user)

--- a/spec/models/hosting_spec.rb
+++ b/spec/models/hosting_spec.rb
@@ -67,4 +67,13 @@ RSpec.describe Hosting, type: :model do
     expect(Hosting.first).to be_nil
     expect(Hosting.with_deleted.first).to eq(hosting)
   end
+
+  it "is invalid earlier than yesterday" do
+    expect { FactoryGirl.create(:hosting, start_date: Date.current - 2.days) }
+      .to raise_error ActiveRecord::RecordInvalid
+  end
+
+  it "is valid starting yesterday" do
+    expect { FactoryGirl.create(:hosting, start_date: Date.current - 1.day) }
+  end
 end

--- a/spec/models/visit_spec.rb
+++ b/spec/models/visit_spec.rb
@@ -53,14 +53,24 @@ RSpec.describe Visit, type: :model do
       .to raise_error ActiveRecord::RecordInvalid
   end
 
-  it "is invalid with a start date in the past" do
+  it "is invalid with a start date two days ago" do
     expect do
       FactoryGirl.create(
         :visit,
-        start_date: Faker::Date.backward(1),
+        start_date: Date.current - 2.day,
         zipcode: "11211"
       )
     end.to raise_error ActiveRecord::RecordInvalid
+  end
+
+  it "is valid with a start date of yesterday" do
+    expect do
+      FactoryGirl.create(
+        :visit,
+        start_date: Date.current - 1.day,
+        zipcode: "11211"
+      )
+    end
   end
 
   it "requires an end date after start date" do


### PR DESCRIPTION
This is to account for differences in time zones between the browser's time zone and the server's (UTC).
